### PR TITLE
Nav consistency with Tina.io

### DIFF
--- a/content/global/index.json
+++ b/content/global/index.json
@@ -131,9 +131,6 @@
         "_template": "navDropdown"
       },
       {
-        "_template": "githubButton"
-      },
-      {
         "label": "Book a Demo",
         "variant": "outline",
         "_template": "demoModal"

--- a/src/components/layout/layout.tsx
+++ b/src/components/layout/layout.tsx
@@ -3,6 +3,7 @@ import { LayoutProvider } from "./layout-context";
 import client from "@/tina/__generated__/client";
 import { Header } from "./nav/header";
 import { Footer } from "./nav/footer";
+import { CloudBanner } from "../ui/cloudBanner";
 
 type LayoutProps = PropsWithChildren & {
   rawPageData?: any;
@@ -23,6 +24,7 @@ export default async function Layout({ children, rawPageData }: LayoutProps) {
 
   return (
     <LayoutProvider globalSettings={globalData.global} pageData={rawPageData}>
+      <CloudBanner />
       <Header />
       <main className="overflow-x-hidden pt-20">
         {children}

--- a/src/components/layout/nav/header.tsx
+++ b/src/components/layout/nav/header.tsx
@@ -3,6 +3,7 @@
 import React from "react";
 import Link from "next/link";
 import Image from "next/image";
+import { usePathname } from "next/navigation";
 import { useLayout } from "../layout-context";
 import { Menu, X } from "lucide-react";
 import { Button } from "../../ui/button";
@@ -14,6 +15,7 @@ import { DoubleItemDropDownButton } from "../../ui/doubleItemDropDownButton";
 
 const NavigationObjectRenderer = ({ navObject }: { navObject: any }) => {
   const template = navObject.__typename;
+  const pathname = usePathname();
 
   switch (template) {
     case "GlobalHeaderNavObjectsDemoModal":
@@ -27,15 +29,19 @@ const NavigationObjectRenderer = ({ navObject }: { navObject: any }) => {
         </ModalButton>
       );
 
-    case "GlobalHeaderNavObjectsNavLink":
+    case "GlobalHeaderNavObjectsNavLink": {
+      const href = navObject.href || "#";
+      const isExternal = href.startsWith("http");
+      const isLinkActive = !isExternal && (pathname === href || (href !== "/" && pathname.startsWith(href + "/")));
       return (
         <Link
-          href={navObject.href || "#"}
-          className="text-neutral-text hover:text-accent-foreground block duration-150"
+          href={href}
+          className={`block duration-150 rounded-lg px-2.5 py-1 transition-colors ${isLinkActive ? "bg-accent text-accent-foreground" : "text-neutral-text hover:bg-accent/50 hover:text-accent-foreground"}`}
         >
           <span>{navObject.label}</span>
         </Link>
       );
+    }
 
     case "GlobalHeaderNavObjectsNavDropdown":
       return <DropdownButton label={navObject.label} links={navObject.links} />;

--- a/src/components/ui/cloudBanner.tsx
+++ b/src/components/ui/cloudBanner.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import Link from "next/link";
+import React, { useEffect, useState } from "react";
+import { getGitHubStarCount } from "@/src/utils/github-star-helper";
+
+const formatStarCount = (count: number) => {
+  const rounded = Math.round(count / 100) * 100;
+  return `${(rounded / 1000).toFixed(1)}k`;
+};
+
+export function CloudBanner() {
+  const [starCount, setStarCount] = useState(0);
+
+  useEffect(() => {
+    const fetchStarCount = async () => {
+      const count = await getGitHubStarCount("tinacms", "tinacms");
+      setStarCount(count);
+    };
+    fetchStarCount();
+  }, []);
+
+  return (
+    <div
+      className="
+        relative z-10 w-full flex flex-col items-center justify-center
+        py-3 px-4 text-base leading-[1.2]
+        bg-secondary/50
+        shadow-[0_0_8px_2px_rgba(0,0,0,0.1)]
+        border-b border-border
+        lg:flex-row lg:pl-8 lg:pr-10
+      "
+    >
+      <div className="flex items-center mt-[0.3rem] mb-2 lg:mb-0">
+        <Link
+          className="pr-2 text-muted-foreground hover:text-foreground transition-colors duration-200 flex items-center gap-1"
+          href="https://github.com/tinacms/tinacms"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Loving Tina?{" "}
+          <svg
+            className="w-4 h-4 ml-1 text-amber-9"
+            fill="currentColor"
+            viewBox="0 0 576 512"
+            aria-hidden="true"
+          >
+            <path d="M259.3 17.8L194 150.2 47.9 171.5c-26.2 3.8-36.7 36.1-17.7 54.6l105.7 103-25 145.5c-4.5 26.3 23.2 46 46.4 33.7L288 439.6l130.7 68.7c23.2 12.2 50.9-7.4 46.4-33.7l-25-145.5 105.7-103c19-18.5 8.5-50.8-17.7-54.6L382 150.2 316.7 17.8c-11.7-23.6-45.6-23.9-57.4 0z" />
+          </svg>{" "}
+          us on GitHub
+          <span className="flex items-center">
+            <svg
+              className="w-5 h-5"
+              fill="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <path
+                fillRule="evenodd"
+                d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"
+                clipRule="evenodd"
+              />
+            </svg>
+            <span className="text-sm font-medium ml-1">
+              {formatStarCount(starCount)}
+            </span>
+          </span>
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/dropdownButton.tsx
+++ b/src/components/ui/dropdownButton.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 import { ChevronDown } from "lucide-react";
 
 interface DropdownLink {
@@ -13,17 +14,34 @@ interface DropdownButtonProps {
   links?: DropdownLink[];
 }
 
+function isRouteActive(
+  pathname: string,
+  links: DropdownLink[] | undefined
+): boolean {
+  if (!links) return false;
+  return links.some((linkItem) => {
+    const href = linkItem.link || "";
+    if (!href || href === "#") return false;
+    // Only match relative (internal) links against the current pathname
+    if (href.startsWith("http")) return false;
+    // Exact match or prefix match for nested routes (e.g. /docs/*)
+    return pathname === href || (href !== "/" && pathname.startsWith(href + "/"));
+  });
+}
+
 export const DropdownButton: React.FC<DropdownButtonProps> = ({
   label,
   links,
 }) => {
   const [isOpen, setIsOpen] = React.useState(false);
+  const pathname = usePathname();
+  const isActive = isRouteActive(pathname, links);
 
   return (
     <>
       {/* Desktop version (lg+) - Hover dropdown */}
       <div className="relative group hidden lg:block">
-        <button className="flex text-neutral-text items-center gap-1 duration-150">
+        <button className={`flex items-center gap-1 duration-150 rounded-lg px-2.5 py-1 transition-colors ${isActive ? "bg-accent text-accent-foreground" : "text-neutral-text hover:bg-accent/50 hover:text-accent-foreground"}`}>
           <span>{label}</span>
           <ChevronDown className="w-3 h-3 transition-transform group-hover:rotate-180" />
         </button>
@@ -49,7 +67,7 @@ export const DropdownButton: React.FC<DropdownButtonProps> = ({
       <div className="block lg:hidden">
         <button
           onClick={() => setIsOpen(!isOpen)}
-          className="flex text-neutral-text items-center gap-1 duration-150 w-full hover:cursor-pointer"
+          className={`flex items-center gap-1 duration-150 w-full hover:cursor-pointer rounded-lg px-2.5 py-1 transition-colors ${isActive ? "bg-accent text-accent-foreground font-medium" : "text-neutral-text"}`}
         >
           <span>{label}</span>
           <ChevronDown

--- a/src/components/ui/githubButton.tsx
+++ b/src/components/ui/githubButton.tsx
@@ -11,7 +11,7 @@ const formatStarCount = (count: number) => {
 
 export const GitHubButton = () => {
   const [count, setCount] = useState(0);
-  
+
   useEffect(() => {
     const fetchStarCount = async () => {
       const count = await getGitHubStarCount('tinacms', 'tinacms');


### PR DESCRIPTION
As per https://github.com/tinacms/tina.io/issues/4181 

- [ ] Reimplements the GitHub Banner at the top of the page
- [ ] Adds nav bar highlighting to show which page we're on 

<img width="1266" height="900" alt="Screenshot 2026-04-14 at 10 49 27 am" src="https://github.com/user-attachments/assets/a37af05c-eef0-4930-82df-840ae5ff1b02" />


**Figure: UI of Nav bar**